### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/.github/workflows/releaseExtension.yml
+++ b/.github/workflows/releaseExtension.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Check for new issues
         uses: hivemq/hivemq-snyk-composite-action@1c18f39e10e7b1d35fa121b91b99c0445b7a4a56 # v2

--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/.github/workflows/snyk-release.yml
+++ b/.github/workflows/snyk-release.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ hivemqExtension {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,7 @@ testing {
                 compileOnly(libs.jetbrains.annotations)
                 implementation(libs.assertj)
                 implementation(libs.mockito)
+                implementation(libs.logback.classic)
             }
             targets.configureEach {
                 testTask {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,11 +78,28 @@ oci {
     }
 }
 
+// see https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3
+val mockitoAgent = configurations.create("mockitoAgent") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+dependencies {
+    mockitoAgent(libs.mockito) { isTransitive = false }
+}
+class MockitoAgentArgumentProvider(@get:Classpath val agentJar: FileCollection) : CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> = listOf("-javaagent:${agentJar.singleFile}")
+}
+
 @Suppress("UnstableApiUsage")
 testing {
     suites {
         withType<JvmTestSuite> {
             useJUnitJupiter(libs.versions.junit.jupiter)
+            targets.configureEach {
+                testTask {
+                    jvmArgumentProviders.add(MockitoAgentArgumentProvider(mockitoAgent))
+                }
+            }
         }
         "test"(JvmTestSuite::class) {
             dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jaxb-impl = "4.0.9"
 jcommander = "1.82"
 jetbrains-annotations = "26.1.0"
 junit-jupiter = "5.10.0"
+logback = "1.6.1"
 mockito = "5.23.0"
 
 [libraries]
@@ -22,6 +23,7 @@ jaxb-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "ja
 jaxb-impl = { module = "org.glassfish.jaxb:jaxb-runtime", version.ref = "jaxb-impl" }
 jcommander = { module = "com.beust:jcommander", version.ref = "jcommander" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 
 [plugins]

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Upgrade the build toolchain to Java 25. Compile target stays at Java 11.

Part of INT-8.